### PR TITLE
Added dosingInstructions 'type' attribute in order to allow for support 

### DIFF
--- a/regimens/5FULeucovorin.yaml
+++ b/regimens/5FULeucovorin.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -50,6 +52,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Mix with 500ml of D5W"
         timing: "Infuse over 2 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -64,6 +67,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "IV Push no dilution needed"
         timing: "IV push over 2-4 minutes. Administer 1 hour into Leucovorin infusion with D5 flush before and after"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/AC.yaml
+++ b/regimens/AC.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -63,6 +66,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 2mg/mL with 0.9% NS. Give via IV push with free flowing 0.9% NS."
         timing: "IV Push over 15 minutes"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -77,6 +81,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 1g/50ml with sterile water for injection. Mix prescribed dose/volume with 500mL 0.9 NS"
         timing: "Infuse over 1-2 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/CHOP.yaml
+++ b/regimens/CHOP.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -50,6 +52,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "PO"
         timing: "Daily x 5 days. 1st dose 60 minutes prio to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -65,6 +68,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 2mg/mL with 0.9% NS. Give via IV push with free flowing 0.9% NS."
         timing: "IV Push over 15 minutes"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -79,6 +83,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "No dilution needed. Give via IV push with free flowing 0.9% NS."
         timing: "IV Push over 1-2 minutes"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -93,6 +98,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 1g/50ml with sterile water for injection. Mix prescribed dose/volume with 500mL 0.9 NS"
         timing: "IV Push over 1-2 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/CMF.yaml
+++ b/regimens/CMF.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,21 +35,23 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
     - # order PREMED 3
-        type: "drugorder"
-        relativeStartDay: 1
-        category: "Premedication" # Concept - "indication" - Premedication, Post medication, Chemotherapy
-        drugConcept: "Ondansetron"
-        drugName: "ondansetron, 4mg, tablet film coated tablet"
-        dose: 8
-        doseUnits: "Milligram"
-        route: "Oral"
-        dosingInstructions:
-          timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
-          dosingAdjustment: 0 # +/- percentage adjustment from regimen order
+      type: "drugorder"
+      relativeStartDay: 1
+      category: "Premedication" # Concept - "indication" - Premedication, Post medication, Chemotherapy
+      drugConcept: "Ondansetron"
+      drugName: "ondansetron, 4mg, tablet film coated tablet"
+      dose: 8
+      doseUnits: "Milligram"
+      route: "Oral"
+      dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
+        timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
+        dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
 # ---------------- CHEMO DRUGS ----------------
 
@@ -62,6 +65,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "No dilution needed"
         timing: "IV push over 10 minutes."
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -76,6 +80,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "No dilution needed"
         timing: "IV push over 10 mg/min."
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -90,6 +95,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 1g/50ml with sterile water for injection. Mix prescribed dose/volume with 500mL 0.9 NS"
         timing: "Infuse over 1-2 hours."
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/COP.yaml
+++ b/regimens/COP.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -50,6 +52,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Oral"
         timing: "Daily x 5 days. 1st dose 60 minutes prio to chemotherapy."
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -64,6 +67,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "No dilution needed. Give via IV push with free flowing 0.9% NS."
         timing: "IV Push over 1-2 minutes"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
@@ -78,6 +82,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 1g/50ml with sterile water for injection. Mix prescribed dose/volume with 500mL 0.9 NS"
         timing: "IV Push over 1-2 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/CarboTaxol.yaml
+++ b/regimens/CarboTaxol.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -60,6 +63,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -73,6 +77,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -88,18 +93,20 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Mix prescribed dose / volume in 500 mL 0.9 NS."
         timing: "Infuse over 3 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
     - # order CHEMO 2
-        type: "drugorder"
-        relativeStartDay: 1
-        category: "Chemotherapy" # Concept - "indication" - Premedication, Post medication, Chemotherapy
-        drugConcept: "Carboplatin"
-        drugName: "CARBOplatin, 10mg/mL, 45mL vial"
-        route: "Intravenous"
-        dosingInstructions:
-          dilution: "Mix prescribed dose / volume in 250 mL 0.9% NS."
-          timing: "Infuse over 1 hours"
-          dosingAdjustment: 0 # +/- percentage adjustment from regimen order
+      type: "drugorder"
+      relativeStartDay: 1
+      category: "Chemotherapy" # Concept - "indication" - Premedication, Post medication, Chemotherapy
+      drugConcept: "Carboplatin"
+      drugName: "CARBOplatin, 10mg/mL, 45mL vial"
+      route: "Intravenous"
+      dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
+        dilution: "Mix prescribed dose / volume in 250 mL 0.9% NS."
+        timing: "Infuse over 1 hours"
+        dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/CyclophosphamideSingleAgent.yaml
+++ b/regimens/CyclophosphamideSingleAgent.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -62,6 +65,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 1g/50ml with sterile water for injection. Mix prescribed dose/volume with 500mL 0.9 NS"
         timing: "Infuse over 1-2 hours."
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/Doxorubicin20.yaml
+++ b/regimens/Doxorubicin20.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -63,6 +66,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 2mg/mL with 0.9% NS. Give via IV push with free flowing 0.9% NS."
         timing: "IV Push over 15 minutes"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/Doxorubicin60.yaml
+++ b/regimens/Doxorubicin60.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"   # another option: "Every hour" ?
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -63,6 +66,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Dilute to 2mg/mL with 0.9% NS. Give via IV push with free flowing 0.9% NS."
         timing: "IV Push over 15 minutes"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/Paclitaxel175.yaml
+++ b/regimens/Paclitaxel175.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to clinic arrival"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -60,6 +63,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -73,6 +77,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -88,6 +93,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Mix prescribed dose / volume with 500mL 0.9% NS."
         timing: "Infuse over 4 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/Paclitaxel175ReChallenge.yaml
+++ b/regimens/Paclitaxel175ReChallenge.yaml
@@ -21,6 +21,7 @@ orderset:
     doseUnits: "Milliliter"
     route: "Intravenous"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "Once prior to chemotherapy"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
     doseUnits: "Milligram"
     route: "Oral"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "12 hours prior to clinic arrival"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
     doseUnits: "Milligram"
     route: "Oral"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "6 hours prior to clinic arrival"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -60,6 +63,7 @@ orderset:
     doseUnits: "Milligram"
     route: "Oral"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "1 hour prior to clinic arrival"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -73,6 +77,7 @@ orderset:
     doseUnits: "Milligram"
     route: "Oral"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "Once 60 minutes prior to chemotherapy"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -86,6 +91,7 @@ orderset:
     doseUnits: "Milligram"
     route: "Oral"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "Once 60 minutes prior to chemotherapy"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -99,6 +105,7 @@ orderset:
     doseUnits: "Milligram"
     route: "Oral"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       timing: "Once 60 minutes prior to chemotherapy"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -114,6 +121,7 @@ orderset:
     doseUnits: "Milligram per square meter"
     route: "Intravenous"
     dosingInstructions:
+      type: "ChemoAdminDosingInstructions"
       dilution: "Mix prescribed dose / volume with 500mL 0.9% NS."
       timing: "Infuse over 4 hours"
       dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/regimens/Paclitaxel80.yaml
+++ b/regimens/Paclitaxel80.yaml
@@ -21,6 +21,7 @@ orderset:
       doseUnits: "Milliliter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -34,6 +35,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -47,6 +49,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -60,6 +63,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -73,6 +77,7 @@ orderset:
       doseUnits: "Milligram"
       route: "Oral"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         timing: "Once 60 minutes prior to chemotherapy"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order
 
@@ -89,6 +94,7 @@ orderset:
       doseUnits: "Milligram per square meter"
       route: "Intravenous"
       dosingInstructions:
+        type: "ChemoAdminDosingInstructions"
         dilution: "Mix prescribed dose / volume with 250mL 0.9% NS."
         timing: "Infuse over 1 hours"
         dosingAdjustment: 0 # +/- percentage adjustment from regimen order

--- a/utils/yaar.py
+++ b/utils/yaar.py
@@ -2,8 +2,8 @@
 # OpenMRS OrderSet (Regimen) lifecycle automated tooling
 #   - query, create, update, retire OrderSets (Regimens)
 # author: Mario De Armas
-# date: 2018.08.03
-# version: 1.0
+# date: 2018.10.31
+# version: 1.1
 
 import sys
 import json
@@ -31,7 +31,7 @@ def displayArgsHelp(errorMissingParam):
     #print "              yaar -purge <config-file> <uuid>"  # <<< action currently not supported by OpenMRS
 
 # start tool implementation
-print "OPENMRS REGIMEN ORDERSET TOOL v1.0 (20180803)..."
+print "OPENMRS REGIMEN ORDERSET TOOL v1.1 (20181031)..."
 
 # check if being invoked to learn args syntax...
 if len(sys.argv) < 3:
@@ -236,6 +236,7 @@ for x in range(len(regimen["orderset"]["orders"])):
     jsonOrderTemplate.doseUnits = regimen["orderset"]["orders"][x].get("doseUnits")
     jsonOrderTemplate.relativeStartDay = regimen["orderset"]["orders"][x]["relativeStartDay"]
     jsonOrderTemplate.dosingInstructions = ObjDict()
+    jsonOrderTemplate.dosingInstructions.type = regimen["orderset"]["orders"][x]["dosingInstructions"]["type"]
     jsonOrderTemplate.dosingInstructions.dosingTimingInstructions = regimen["orderset"]["orders"][x]["dosingInstructions"]["timing"]
     jsonOrderTemplate.dosingInstructions.dosingDilutionInstructions = regimen["orderset"]["orders"][x]["dosingInstructions"].get("dilution")
     jsonOrderTemplate.dosingInstructions.dosingAdjustmentPercentage = regimen["orderset"]["orders"][x]["dosingInstructions"]["dosingAdjustment"]


### PR DESCRIPTION
Added dosingInstructions 'type' attribute in order to allow for support of different dosing type classes (futures) in a regimen (orderset).